### PR TITLE
Fixing aws-cli regression.

### DIFF
--- a/src/start-remote-signer.sh
+++ b/src/start-remote-signer.sh
@@ -38,7 +38,8 @@ load_password() {
 	export HSM_PASSWORD=`aws --region=$REGION ssm get-parameters \
 		--name /hsm/$HSMID/password \
 		--with-decryption \
-		--output text | cut -f 6`
+		--output text \
+		--query 'Parameters[*].Value'`
 	if [ $? -ne 0 ]
 	then
 		echo "SSM Error retrieving password"


### PR DESCRIPTION
Fixes an aws cli regression where AWS keeps changing the field position in CLI output. By using a query string we can avoid breaking changes like this in the future.