### PR TITLE
Revert "Bump urllib3 from 1.24.3 to 1.26.5"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@ pyblake2==1.1.2
 python-dateutil==2.8.0
 s3transfer==0.2.0
 six==1.12.0
-urllib3==1.26.5
+urllib3==1.24.3
 uuid==1.30
 Werkzeug==0.15.3


### PR DESCRIPTION
This reverts commit 376a2d841b2de762fa3722631e5dc889b5fe40ce.

Turns out botocore==1.12.142 wants urllib<=1.25.0