### PR TITLE
SignatureRequest no longer throws invalid message tag

### DIFF
--- a/signer.py
+++ b/signer.py
@@ -11,11 +11,7 @@ import logging
 
 def logreq(sigreq, msg):
     if sigreq != None:
-        chainid = sigreq.get_chainid()
-        type = sigreq.get_type()
-        level = sigreq.get_level()
-        round = sigreq.get_round()
-        logging.info(f"Request: {chainid} {type} at {level}/{round}:{msg}")
+        logging.info(f"Request: {sigreq.get_logstr()}:{msg}")
 
 logging.basicConfig(filename='./remote-signer.log',
                     format='%(asctime)s %(threadName)s %(message)s',

--- a/src/sigreq.py
+++ b/src/sigreq.py
@@ -47,7 +47,11 @@ class SignatureReq:
             self.round = get_be_int(data[44:])
 
         else:
-            raise(Exception('Unsupported signature request tag'))
+            self.type = "Unknown operation"
+
+        self.logstr = f"{self.chainid} {self.type}"
+        if self.level != None:
+            self.logstr += f" at {self.level}/{self.round}"
 
     def get_payload(self):
         return self.payload
@@ -63,3 +67,6 @@ class SignatureReq:
 
     def get_round(self):
         return self.round
+
+    def get_logstr(self):
+        return self.logstr

--- a/src/validatesigner.py
+++ b/src/validatesigner.py
@@ -8,6 +8,7 @@ import logging
 
 from src.sigreq import SignatureReq
 
+baking_req_types = ["Baking", "Endorsement", "Preendorsement" ]
 
 class ValidateSigner:
     def __init__(self, config, ratchet=None, subsigner=None):
@@ -17,6 +18,9 @@ class ValidateSigner:
         self.node_addr = config['node_addr']
 
     def sign(self, handle, sigreq):
+        if sigreq.get_type() not in baking_req_types:
+            raise(Exception("Unsupported signature request tag"))
+
         sig_type = f"{sigreq.get_type()}_{sigreq.get_chainid()}"
         logging.debug(f"About to sign {sigreq.get_payload()} " +
                       f"with key handle {handle}")


### PR DESCRIPTION
Because of our restructure in 90f0af61f, it no longer makes sense
for SignatureRequest to throw an exception if it doesn't understand
the message tag.  We modify the code to parse as much of the sigreq
as possible and let ValidateSigner apply the policy of restricting
to only certain kinds of signatures.  In the future, we will have
to distinguish between sigreqs that require and don't require the
ratchet...