### PR TITLE
First pass at multikey support within cloud formation

### DIFF
--- a/cloudformation/template
+++ b/cloudformation/template
@@ -55,18 +55,8 @@ Parameters:
   HSMSlot:
     Type: Number
     Default: 1
-  HSMPubKeyHandle:
-    Type: Number
-    Default: 2
-  HSMPrivKeyHandle:
-    Type: Number
-    Default: 3
-  HSMPubKey:
-    Type: String
-    Default: replace with public key
-  HSMPubKeyHash:
-    Type: String
-    Default: replace with tz3 public key hash
+  HSMKeys:
+    Type: List<String>
   HSMLibFile:
     Type: String
     Default: /opt/cloudhsm/lib/libcloudhsm_pkcs11.so
@@ -103,18 +93,8 @@ Metadata:
         default: The username we will login to the CloudHSM with
       HSMSlot:
         default: 'The slot in the CloudHSM we are using, typically 1'
-      HSMPubKeyHandle:
+      HSMKeys:
         default: The handle of the public key that we will base58 encode
-      HSMPrivKeyHandle:
-        default: The handle of the private key that we will use to sign
-      HSMPubKey:
-        default: >-
-          The base58 encoded public key that matches the public key referenced
-          in PubKeyHandle
-      HSMPubKeyHash:
-        default: >-
-          The base58 encoded public key hash that matches the public key
-          referenced in PubKeyHandle
       HSMLibFile:
         default: Typically /opt/cloudhsm/lib/libcloudhsm_pkcs11.so
     ParameterGroups:
@@ -144,10 +124,7 @@ Metadata:
           - HSMAddress
           - HSMUser
           - HSMSlot
-          - HSMPubKeyHandle
-          - HSMPrivKeyHandle
-          - HSMPubKey
-          - HSMPubKeyHash
+          - HSMKeys
           - HSMLibFile
 Resources:
   SecurityGroup:
@@ -401,26 +378,24 @@ Resources:
       Name: !Sub '/hsm/${HSMID}/${AWS::StackName}/keys'
       Description: 'A JSON containing the public keys, hashes, and slots used'
       Type: String
-      Value: !Sub |
-        {
-          "aws_region": "${AWS::Region}",
-          "bind_addr": "0.0.0.0",
-          "ddb_table": "${DynamoDBTable}",
-          "hsm_username": "${HSMUser}",
-          "hsm_slot": ${HSMSlot},
-          "hsm_lib": "${HSMLibFile}",
-          "keys": {
-            "${HSMPubKeyHash}": {
-              "public_key": "${HSMPubKey}",
-              "private_handle": ${HSMPrivKeyHandle},
-              "public_handle": ${HSMPubKeyHandle}
+      Value:
+        !Sub
+        - |
+          {
+            "aws_region": "${AWS::Region}",
+            "aws_stackname": "${AWS::StackName}",
+            "bind_addr": "0.0.0.0",
+            "ddb_table": "${DynamoDBTable}",
+            "hsm_username": "${HSMUser}",
+            "hsm_slot": ${HSMSlot},
+            "hsm_lib": "${HSMLibFile}",
+            "keys": [ "${Keys}" ],
+            "policy": {
+              "baking": 1,
+              "voting": [ "pass" ]
             }
-          },
-          "policy": {
-            "baking": 1,
-            "voting": [ "pass" ]
           }
-        }
+        - Keys: !Join ["\", \"", !Ref HSMKeys]
   DynamoDBTable:
     Type: 'AWS::DynamoDB::Table'
     Properties:

--- a/scripts/signer
+++ b/scripts/signer
@@ -7,6 +7,8 @@ from tezos_signer import SignatureReq, ValidateSigner, DDBChainRatchet, \
 from os import path, environ
 import logging
 
+from pytezos_core.key import Key
+
 def logreq(sigreq, msg):
     if sigreq != None:
         logging.info(f"Request: {sigreq.get_logstr()}:{msg}")
@@ -43,6 +45,35 @@ if path.isfile('keys.json'):
         json_blob = myfile.read().replace('\n', '')
         config = json.loads(json_blob)
         logging.info(f"Loaded config contains: {json.dumps(config, indent=2)}")
+
+    new_keys = {}
+    for k in config["keys"]:
+        try:
+            l = k.split(":")
+            if len(l) == 3:
+                encoded_key = l[0]
+                private_handle = l[1]
+                public_handle = l[2]
+            else:
+                if not isinstance(config['keys'], dict):
+                    raise(Exception(f'Malformed key: "k"'))
+                if not isinstance(config['keys'][k], dict):
+                    raise(Exception(f'Malformed key: {config["keys"][k]}'))
+                encoded_key = k
+                private_handle = config['keys'][k]['private_handle']
+                public_handle = config['keys'][k]['public_handle']
+            key = Key.from_encoded_key(encoded_key)
+            new_keys[key.public_key_hash()] = {
+                "public_key": key.public_key(),
+                "private_handle": private_handle,
+                "public_handle": public_handle
+            }
+        except Exception as e:
+            logging.info(str(e))
+            new_keys[k] = config["keys"][k]
+            pass
+
+    config["keys"] = new_keys
 
 #
 # We keep the ChainRatchet, HSM, and ValidateSigner outside sign()


### PR DESCRIPTION
So, in order to support it, we decided to change the many strings representing public key hash, public key, private handle, and public handle into a single string which is colon separated public key, private key handle, public key handle. We generate the public key hash from the public key, so there's no point in including both. Then the field that accepts them will take a list of said strings and it will be appropriate parsed into the correct way in the remote-signer.
The remote-signer retains compatibility with the old format.
We think that this may not be the final format, so let's have a think about it before we commit to it. We think that we should at least include the type of HSM so the format could be:

```
        "edsk..."                         a private key in which case the remote signer just does it.
        "p2pk...:TYPE:ARG1:ARG2:...:ARGN" a public key followed by TYPE = HSM or KMS,
                                          and parameters based on the type.
```